### PR TITLE
Upgrade & Pin lodash version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.1",
-    "lodash": "^4.14.2",
+    "lodash": "4.17.15",
     "semver": "^5.3.0"
   }
 }


### PR DESCRIPTION
Upgrade lodash to last supported by this module version (next crashes it)

After this version, the module crashes with this error:

```
webb_1      |       Cannot read property 'response' of undefined
webb_1      | 
webb_1      |       at Client_PG.processResponse (/app/node_modules/knex/lib/dialects/postgres/index.js:248:22)
webb_1      |       at /app/node_modules/knex/lib/runner.js:161:35
webb_1      |       at clsBind (/app/node_modules/cls-hooked/context.js:172:17)
webb_1      |       at processImmediate (internal/timers.js:458:21)
webb_1      |       at process.topLevelDomainCallback (domain.js:138:15)
webb_1      |       at process.callbackTrampoline (internal/async_hooks.js:121:14)
webb_1      |   From previous event:
webb_1      |       at Promise.then (/app/node_modules/cls-bluebird/lib/shimMethod.js:38:20)
webb_1      |       at Runner.query (/app/node_modules/knex/lib/runner.js:161:8)
webb_1      |       at /app/node_modules/knex/lib/runner.js:40:23
webb_1      |       at /app/node_modules/knex/lib/runner.js:277:24
webb_1      |       at propagateAslWrapper (/app/node_modules/async-listener/index.js:504:23)
webb_1      |       at proxyWrapper (/app/node_modules/async-listener/index.js:531:16)
webb_1      |       at /app/node_modules/async-listener/index.js:541:70
webb_1      |       at /app/node_modules/async-listener/glue.js:188:31
```