### PR TITLE
Protect replace from modifying the prototype

### DIFF
--- a/src/util/transformer.js
+++ b/src/util/transformer.js
@@ -32,11 +32,12 @@ class Mocker {
   _replace(obj, spec, replaced, path) {
     let replacement = _.get(spec, path);
 
-    path = path.replace('._constructor.', '.constructor.');
+    path = path.replace('._constructor.', '.constructor.').replace('._prototype.', '.prototype.');
 
     const context = this.context(obj, path);
     const name = _.last(path.split('.'));
-    const replacedPath = path.replace('.constructor.', '._constructor.');
+    const replacedPath = path.replace('.constructor.', '._constructor.').replace('.prototype.', '._prototype.');
+    
 
     if (! _.get(replaced, path)) {
       _.set(replaced, replacedPath, _.get(obj, path));


### PR DESCRIPTION
mock(Knex) is storing the original functions on a replacement object,  but when being set lodash is storing it on the real object prototype. This change modifies the replacement storage to put the function on a renamed prototype object much like the constructor.

This allows unmock(Knex) to properly restore all mocked functions.

Fixes #126